### PR TITLE
Update Gids.cc to make it work with BSD family

### DIFF
--- a/src/Gids.cc
+++ b/src/Gids.cc
@@ -6,11 +6,7 @@
 #if !defined(_WIN32)
 #include <grp.h>
 #include <pwd.h>
-
-// BSD needs unistd.h for getgrouplist function
-#if defined(BSD) || defined(__APPLE__)
 #include <unistd.h>
-#endif
 
 #else
 // Mocks for Windows


### PR DESCRIPTION
BSD requires sys/param.h. Instead of including param.h and checking for BSD, we can just include the unistd.h